### PR TITLE
fix issue where Update#execute() throws NPE in some cases. Closes #66.

### DIFF
--- a/src/main/java/com/sigpwned/jdbq/statement/Update.java
+++ b/src/main/java/com/sigpwned/jdbq/statement/Update.java
@@ -19,6 +19,7 @@
  */
 package com.sigpwned.jdbq.statement;
 
+import java.util.Optional;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobStatistics;
 import com.sigpwned.jdbq.Handle;
@@ -46,6 +47,6 @@ public class Update extends SqlStatement<Update> {
   public long execute() {
     Job job = internalExecute();
     JobStatistics.QueryStatistics statistics = job.getStatistics();
-    return statistics.getNumDmlAffectedRows();
+    return Optional.ofNullable(statistics.getNumDmlAffectedRows()).orElse(0L);
   }
 }

--- a/src/main/java/com/sigpwned/jdbq/statement/Update.java
+++ b/src/main/java/com/sigpwned/jdbq/statement/Update.java
@@ -47,6 +47,7 @@ public class Update extends SqlStatement<Update> {
   public long execute() {
     Job job = internalExecute();
     JobStatistics.QueryStatistics statistics = job.getStatistics();
+    // Return 0 if statistics.getNumDmlAffectedRows() is null to prevent a NullPointerException (NPE)
     return Optional.ofNullable(statistics.getNumDmlAffectedRows()).orElse(0L);
   }
 }


### PR DESCRIPTION
Returns 0 when no rows are affected.